### PR TITLE
feat: task system overhaul — bidirectional sync, recurring schedules, persistent chat history

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const {
 } = require("./src/lib/openclaw-gateway.js");
 const { parseNpcResponse, isValidTaskAction } = require("./src/lib/task-parser.js");
 const { TaskManager } = require("./src/lib/task-manager.js");
-const { withTaskReminder, normalizeTaskPromptLocale } = require("./src/lib/task-prompt.js");
+const { withTaskReminder, normalizeTaskPromptLocale, buildTaskSessionPrompt } = require("./src/lib/task-prompt.js");
 const {
   getInternalSocketHostname,
   isInternalRequestAuthorized,
@@ -495,31 +495,32 @@ async function main() {
     }
   }
 
-  async function streamNpcResponse(socket, npcId, npcConfig, userId, message) {
+  async function streamNpcResponse(socket, npcId, npcConfig, userId, message, sessionKeyOverride, responseEvent) {
     const agentId = npcConfig.agentId || npcConfig.agent_id || null;
+    const eventName = responseEvent || "npc:response";
     if (!agentId) {
-      socket.emit("npc:response", { npcId, chunk: "[This NPC has no AI agent connected]", done: true });
+      socket.emit(eventName, { npcId, chunk: "[This NPC has no AI agent connected]", done: true });
       return "";
     }
 
     const channelId = npcConfig._channelId;
     const gateway = channelId ? await getOrConnectGateway(channelId) : null;
     if (!gateway) {
-      socket.emit("npc:response", { npcId, chunk: "[Gateway not connected]", done: true });
+      socket.emit(eventName, { npcId, chunk: "[Gateway not connected]", done: true });
       return "";
     }
 
-    const sessionKey = `${npcConfig.sessionKeyPrefix || npcId}-dm-${userId}`;
+    const sessionKey = sessionKeyOverride || `${npcConfig.sessionKeyPrefix || npcId}-dm-${userId}`;
 
     try {
       const response = await gateway.chatSend(agentId, sessionKey, message, (delta) => {
-        socket.emit("npc:response", { npcId, chunk: delta, done: false });
+        socket.emit(eventName, { npcId, chunk: delta, done: false });
       });
-      socket.emit("npc:response", { npcId, chunk: "", done: true });
+      socket.emit(eventName, { npcId, chunk: "", done: true });
       return response;
     } catch (err) {
       console.error("[npc] Chat error:", err.message);
-      socket.emit("npc:response", { npcId, chunk: "[AI Gateway error]", done: true });
+      socket.emit(eventName, { npcId, chunk: "[AI Gateway error]", done: true });
       return "";
     }
   }
@@ -713,6 +714,98 @@ ${transcript}
       } catch (err) {
         console.error("[TaskManager] Error fetching tasks:", err);
         socket.emit("task:list-response", { tasks: [], npcId: npcId || null });
+      }
+    });
+
+    socket.on("task:create", async ({ channelId, title, summary, npcId }) => {
+      try {
+        const player = players.get(socket.id);
+        if (!player) return;
+
+        if (!channelId || typeof channelId !== "string") return;
+        if (typeof title !== "string") return;
+
+        const trimmedTitle = title.trim().slice(0, 200);
+        if (!trimmedTitle) return;
+        const trimmedSummary = typeof summary === "string" ? summary.trim() : null;
+
+        let task = await taskManager.createBacklogTask(channelId, player.characterId, trimmedTitle, trimmedSummary);
+        if (npcId) {
+          task = await taskManager.moveTask(task.id, player.mapId, "pending", npcId);
+        }
+
+        if (task) {
+          io.to(player.mapId).emit("task:updated", { task, action: "create" });
+        }
+      } catch (err) {
+        console.error("[TaskManager] Error creating task:", err);
+      }
+    });
+
+    socket.on("task:move", async ({ taskId, toStatus, npcId }) => {
+      try {
+        const player = players.get(socket.id);
+        if (!player || !taskId || !toStatus) return;
+
+        const allowedStatuses = ["backlog", "pending", "in_progress", "stalled", "complete", "cancelled"];
+        if (!allowedStatuses.includes(toStatus)) return;
+
+        const movedTask = await taskManager.moveTask(taskId, player.mapId, toStatus, npcId || null);
+        if (!movedTask) return;
+
+        const fromStatus = movedTask._fromStatus;
+        const { _fromStatus, ...task } = movedTask;
+        io.to(player.mapId).emit("task:updated", { task, action: `move_${fromStatus}_${toStatus}` });
+
+        // Auto-execute task when moved to in_progress with an assigned NPC
+        if (
+          toStatus === "in_progress" &&
+          (fromStatus === "backlog" || fromStatus === "pending") &&
+          task.npcId
+        ) {
+          const npcConfig = await getNpcConfig(task.npcId);
+          if (npcConfig) {
+            const locale = getSocketLocale(socket);
+            const taskSessionPrompt = buildTaskSessionPrompt({
+              ...task,
+              summary: task.summary || "",
+              createdAt: task.createdAt || "",
+            }, locale);
+            const autoStartMessage = withTaskReminder(`${task.title} 업무를 시작합니다.`, locale);
+            const messageToSend = `${taskSessionPrompt}\n\n${autoStartMessage}`;
+            const sessionKey = `${npcConfig.sessionKeyPrefix || task.npcId}-task-${task.npcTaskId}`;
+
+            const response = await streamNpcResponse(
+              socket,
+              task.npcId,
+              npcConfig,
+              player.userId,
+              messageToSend,
+              sessionKey,
+              "npc:task-response",
+            );
+
+            if (response) {
+              const parsed = parseNpcResponse(response);
+              await processNpcTaskActions(parsed, {
+                channelId: player.mapId,
+                npcId: task.npcId,
+                npcName: npcConfig._name,
+                assignerCharacterId: player.characterId,
+                targetUserId: player.userId,
+              });
+              socket.emit("npc:response-complete", {
+                npcId: task.npcId,
+                npcName: npcConfig._name || task.npcId,
+              });
+            }
+          }
+        }
+      } catch (err) {
+        console.error("[TaskManager] Error moving task:", err);
+        if (err instanceof Error && err.message.includes("npcId required")) {
+          socket.emit("task:move-error", { error: "npcId_required" });
+        }
       }
     });
 

--- a/src/app/game/GamePageClient.tsx
+++ b/src/app/game/GamePageClient.tsx
@@ -2178,7 +2178,7 @@ function GamePageInner() {
         isOpen={showTaskBoard}
         onClose={() => setShowTaskBoard(false)}
         tasks={allTasks}
-        npcs={channelNpcs.map((npc: any) => ({ id: npc.id, name: npc.name, isActive: Boolean(npc.openclawConfig) }))}
+        npcs={channelNpcs.map((npc: any) => ({ id: npc.id, name: npc.name, isActive: Boolean(npc.hasAgent ?? npc.openclawConfig) }))}
         onDeleteTask={deleteTask}
         onRequestReportTask={requestTaskReport}
         onResumeTask={resumeTask}

--- a/src/server/socket-handlers.ts
+++ b/src/server/socket-handlers.ts
@@ -770,8 +770,10 @@ async function persistMeetingMinutes(input: {
 // JWT helpers
 // ---------------------------------------------------------------------------
 
+const DEV_JWT_SECRET = "deskrpg-dev-jwt-secret-do-not-use-in-production";
+
 function getJwtSecret() {
-  const secret = process.env.JWT_SECRET;
+  const secret = process.env.JWT_SECRET || (process.env.NODE_ENV !== "production" ? DEV_JWT_SECRET : "");
   if (!secret) throw new Error("Missing JWT_SECRET");
   return new TextEncoder().encode(secret);
 }
@@ -1313,7 +1315,6 @@ export function setupSocketHandlers(io: Server) {
             const autoStartMessage = withTaskReminder(`${task.title} 업무를 시작합니다.`, getSocketLocale(socket));
             const messageToSend = `${taskSessionPrompt}\n\n${autoStartMessage}`;
             const sessionKey = `${npcConfig.sessionKeyPrefix || task.npcId}-task-${task.npcTaskId}`;
-
             const response = await streamNpcResponse(
               socket,
               task.npcId,


### PR DESCRIPTION
## 개요

이 PR은 DeskRPG의 태스크 시스템을 전면적으로 개선합니다. 채팅과 태스크의 양방향 동기화, 반복 스케줄 자동 실행, 태스크 채팅 히스토리 영속화 등의 기능을 추가하고, 발견된 여러 버그를 수정합니다.

## 1. 버그 수정

### 1.1 `server.js` 누락된 소켓 핸들러
- `task:create`, `task:move` 핸들러가 socket-handlers.ts(dev)에만 있고 server.js(prod)에 없어서 프로덕션에서 태스크 생성/이동 불가
- 두 핸들러를 server.js에 포팅, `streamNpcResponse`에 sessionKeyOverride/responseEvent 파라미터 추가
- `getJwtSecret()` dev fallback 추가

### 1.2 NPC 활성 상태 판별 오류
- TaskBoard의 NPC 할당 모달에서 모든 NPC가 \"비활성\"으로 표시됨
- API가 반환하는 \`hasAgent\` 필드 대신 (반환하지 않는) \`openclawConfig\`를 참조하던 것 수정

### 1.3 NPC 패널 태스크 생성 시 channelId 누락
- NpcDialog/ChatPanel → TaskPanel로 channelId가 전달되지 않아 \`if (!channelId) return;\`로 무시됨
- 전 경로 prop drilling 추가

## 2. 양방향 태스크-채팅 동기화 (R1~R4)

### R4. 통합 태스크 ID 시스템
- 모든 태스크 ID를 서버가 생성: 형식 \`task-YYYYMMDD-xxxx\`
- NPC가 ID를 자체 생성하지 않도록 프로토콜 변경 (\`buildTaskCorePrompt\`)
- \`isValidTaskAction\`에서 \`create\` 액션의 \`id\` 필드를 선택적으로 변경
- \`processNpcTaskActions\`에서 NPC가 보낸 ID는 무시하고 서버 ID로 덮어씀

### R1. 사용자가 태스크 등록을 결정 (asTask 토글)
- ChatInput에 \"태스크 등록 ON/OFF\" 명시적 토글 바 추가
  - 입력란 위에 라벨 + ON/OFF 뱃지로 명확히 표시
  - 도움말 \`?\` 버튼 (툴팁으로 설명)
  - 기본값 ON
  - 전송 버튼 텍스트 동적 변경 (\"태스크 전송\" / \"전송\")
- ON 상태로 메시지 전송 시:
  1. 서버가 즉시 태스크를 DB에 등록 (createBacklogTask + moveTask in_progress)
  2. NPC에게 \`[SYSTEM: Task pre-registered with ID ...]\` 지시문으로 메시지 래핑
  3. NPC는 update 액션으로 진행 보고
- NPC가 자체 태스크 생성하는 경로는 deprecated (프로토콜에서 제거)

### R2. 세션 컨텍스트 동기화
- \`buildTaskSummaryContext()\` 추가: 활성 태스크 목록을 \`[CURRENT TASKS]\` 블록으로 직렬화
- \`npc:chat\` 핸들러에서 매 메시지에 NPC의 활성 태스크 스냅샷 주입 → NPC가 보드 태스크를 인지
- \`npc:task-chat\` 핸들러에서 최근 3개 DM 메시지를 \`[RECENT DM CONTEXT]\` 블록으로 주입 → 태스크 세션이 DM 맥락 인지

### R3. 태스크 실행 결과 채팅 미러링
- \`task:move\` 자동실행 완료 후 \`npc:task-chat-mirror\` 이벤트 발행
- 클라이언트는 채팅탭의 \`npcMessages\`에 인라인 TaskCard와 함께 표시
- 결과 500자로 잘라서 표시, 전체는 태스크 채팅뷰에서 확인

## 3. 반복 스케줄 (Recurring Tasks)

### Phase 1: DB + Cron 파서
- \`scheduled_tasks\` 테이블 추가 (PG + SQLite + 마이그레이션)
- \`tasks.scheduled_task_id\` FK 컬럼 추가
- \`src/lib/cron-parser.ts\` 신규: 외부 의존성 없는 5필드 cron 파서
  - \`cronMatchesNow()\`, \`getNextCronRun()\`, \`validateCronExpr()\`, \`cronToHumanKo()\`
  - 타임존 지원 (\`Intl.DateTimeFormat\`)

### Phase 2: 서버 스케줄러
- \`ScheduledTaskManager\` 클래스: CRUD, getDueSchedules, markExecuted, history
- \`scanScheduledTasks()\` — 60초 간격 스캐너:
  - 자식 태스크 생성 → in_progress 이동 → NPC 게이트웨이 직접 호출 (소켓 불필요)
  - 사용자 오프라인 상태에서도 동작
  - 결과는 npcReports + tasks.last_response에 저장
- \`scheduledTaskInFlight\` Set로 동시 실행 방지

### Phase 3: 소켓 이벤트
- \`schedule:create/update/delete/list/toggle/history\` CRUD
- \`schedule:executed\` 실시간 알림
- cron 표현식 검증 후 에러 응답

### Phase 4: UI
- \`ScheduleCreateForm\`: 제목/설명, cron 프리셋(매일 9시/매일 18시/매주 월요일/매시간), 고급 cron 입력
- \`ScheduleListPanel\`: 스케줄 목록, ON/OFF 토글, 삭제, 다음 실행 시각
- \`ScheduleBoard\`: 별도 모달 컴포넌트 (TaskBoard와 분리)
- 게임 헤더에 \"⏱️ 반복스케줄\" 버튼 추가

## 4. 태스크 채팅 히스토리 영속화

### 문제
- \`npcTaskMessages\`가 클라이언트 메모리에만 있어서 새로고침 시 사라짐
- 서버 단독 실행된 스케줄 태스크는 클라이언트에 메시지가 없음

### 해결 (B+D 조합)
- **D**: \`tasks.last_response\` 컬럼 추가 — NPC 응답 영속화
- **B**: \`npc:task-history\` 소켓 이벤트로 \`npcReports\` + \`last_response\` fallback 조회
- 응답 저장 지점:
  - \`task:move\` 자동실행 후
  - \`npc:task-chat\` 후
  - \`scanScheduledTasks\` 후
  - \`npc:chat\` (asTask 사전 등록 경로) 후

### 태스크 카드 → NPC 채팅뷰 자동 이동
- TaskBoard 태스크 카드 클릭 시:
  1. \`onOpenNpcTask(npcId, npcTaskId)\` 호출
  2. 태스크 보드 닫고 NPC 다이얼로그 열기
  3. \`activeTaskId\` 설정 → ChatPanel이 자동으로 태스크 탭 활성화
  4. \`npc:task-history\` 요청 → 서버에서 메시지 반환 → \`npcTaskMessages\`에 채워넣음
  5. TaskChatView가 자동으로 표시

### NPC 다이얼로그 자동 닫힘 방지
- Phaser GameScene이 매 프레임 \"근처에 NPC가 없으면 다이얼로그 자동 닫기\"를 체크하여, 태스크 보드에서 연 다이얼로그가 즉시 닫히는 버그
- \`dialog:open-manual\` EventBus 이벤트 추가
- GameScene에 \`dialogManual\` 플래그, true일 때 자동 닫기 스킵
- \`dialog:close\` 시 플래그 리셋

## 5. UX 개선

### 채팅창 태스크 추가 버튼 제거
- NPC 채팅창의 \"+ 이 NPC에 태스크 추가\" 버튼 제거
- 이유: 채팅 입력 토글이 동일 기능을 제공하므로 진입점 일원화
- TaskPanel은 *조회 전용*으로 단순화

### 태스크 등록 알림
- 태스크가 등록되거나 NPC에 할당될 때 채팅탭에 \"📋 새 태스크가 등록되었습니다: ...\" 시스템 메시지 표시
- 인라인 TaskCard와 함께 표시되어 클릭하면 해당 태스크로 이동 가능

### 폰트 크기 조정
- TaskCreateForm, ScheduleCreateForm, TaskCard, TaskBoard 헤더 등 전반적으로 폰트 크기 키움 (가독성 개선)

### TaskBoard / ScheduleBoard 분리
- 처음에는 TaskBoard에 스케줄 탭으로 통합했으나, 사용자 요청에 따라 별도 모달로 분리
- 게임 헤더에 각각 별도 버튼 (\"태스크\", \"반복스케줄\")

## 변경 파일

### 신규 (8)
- \`src/lib/cron-parser.ts\`
- \`src/lib/scheduled-task-manager.ts\`
- \`src/components/ScheduleCreateForm.tsx\`
- \`src/components/ScheduleListPanel.tsx\`
- \`src/components/ScheduleBoard.tsx\`

### 수정 (주요)
- \`src/db/schema.ts\` / \`schema-sqlite.ts\` / \`sqlite-base-schema.js\` / \`index.ts\`
- \`src/lib/task-manager.js\` / \`task-prompt.js\` / \`task-parser.js\`
- \`src/server/socket-handlers.ts\` (대규모 수정)
- \`server.js\` (프로덕션 미러링)
- \`src/app/game/GamePageClient.tsx\`
- \`src/components/TaskBoard.tsx\` / \`TaskCard.tsx\` / \`TaskPanel.tsx\` / \`TaskCreateForm.tsx\`
- \`src/components/ChatInput.tsx\` / \`ChatPanel.tsx\` / \`NpcDialog.tsx\`
- \`src/game/scenes/GameScene.ts\`
- \`src/lib/i18n/locales/ko.ts\` / \`en.ts\`

## DB 마이그레이션

새 컬럼/테이블이 \`ensureSqliteCompatibility()\`에서 자동 마이그레이션됩니다 (SQLite). PostgreSQL은 별도 마이그레이션 도구 사용 필요.

- \`tasks.scheduled_task_id\` (TEXT/UUID, FK)
- \`tasks.last_response\` (TEXT)
- \`scheduled_tasks\` 테이블 (전체)

## Test plan

- [x] 태스크 보드: 태스크 생성/할당/이동/삭제
- [x] NPC 채팅에서 \"태스크 등록 ON\"으로 메시지 전송 → 태스크 자동 생성 + 실행
- [x] 반복 스케줄 등록 → 1분 후 NPC가 자동 실행
- [x] 태스크 카드 클릭 → NPC 채팅창의 태스크 탭으로 이동, 결과 표시
- [x] 새로고침 후에도 태스크 채팅 히스토리 유지
- [x] NPC 채팅에서 \"지금 진행 중인 태스크 뭐야?\" → NPC가 보드 태스크 인지
- [x] 게임 헤더 \"반복스케줄\" 버튼 → 별도 모달

🤖 Generated with [Claude Code](https://claude.com/claude-code)