### PR TITLE
feat: task board UX improvements

### DIFF
--- a/src/components/TaskBoard.tsx
+++ b/src/components/TaskBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import TaskCard from "./TaskCard";
 import type { Task } from "./TaskCard";
 import TaskCreateForm from "./TaskCreateForm";
@@ -8,7 +8,7 @@ import NpcAssignModal from "./NpcAssignModal";
 import DroppableColumn from "./DroppableColumn";
 import DraggableTaskCard from "./DraggableTaskCard";
 import { useT } from "@/lib/i18n";
-import { ClipboardList, X, Clock, Loader, CheckCircle, PauseCircle, Inbox } from "lucide-react";
+import { ClipboardList, X, Clock, Loader, CheckCircle, PauseCircle, Inbox, FileText } from "lucide-react";
 import type { Socket } from "socket.io-client";
 
 interface NpcInfo {
@@ -57,6 +57,11 @@ export default function TaskBoard({
     taskId: string;
     taskTitle: string;
     toStatus: string;
+  } | null>(null);
+  const [reportModal, setReportModal] = useState<{
+    task: Task;
+    message: string | null;
+    loading: boolean;
   } | null>(null);
 
   const npcList = useMemo(() => {
@@ -123,8 +128,28 @@ export default function TaskBoard({
   const handleAssignClick = useCallback((taskId: string) => {
     const task = tasks.find((t) => t.id === taskId);
     if (!task) return;
-    setAssignModal({ taskId, taskTitle: task.title, toStatus: "pending" });
+    setAssignModal({ taskId, taskTitle: task.title, toStatus: "in_progress" });
   }, [tasks]);
+
+  const handleTaskClick = useCallback((taskId: string) => {
+    if (!socket) return;
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task) return;
+    setReportModal({ task, message: null, loading: true });
+    socket.emit("task:get-report", { taskId });
+  }, [socket, tasks]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = ({ taskId, message }: { taskId: string; message: string | null }) => {
+      setReportModal((prev) => {
+        if (!prev || prev.task.id !== taskId) return prev;
+        return { ...prev, message, loading: false };
+      });
+    };
+    socket.on("task:report", handler);
+    return () => { socket.off("task:report", handler); };
+  }, [socket]);
 
   if (!isOpen) return null;
 
@@ -140,7 +165,7 @@ export default function TaskBoard({
             <div className="flex gap-1">
               <button
                 onClick={() => setFilterNpc(null)}
-                className={`px-2 py-0.5 rounded text-[10px] ${
+                className={`px-2 py-0.5 rounded text-[12px] ${
                   !filterNpc ? "bg-primary text-white" : "bg-surface text-text-muted"
                 }`}
               >
@@ -150,7 +175,7 @@ export default function TaskBoard({
                 <button
                   key={id}
                   onClick={() => setFilterNpc(id)}
-                  className={`px-2 py-0.5 rounded text-[10px] ${
+                  className={`px-2 py-0.5 rounded text-[12px] ${
                     filterNpc === id ? "bg-primary text-white" : "bg-surface text-text-muted"
                   }`}
                 >
@@ -172,7 +197,7 @@ export default function TaskBoard({
                 status={col.status}
                 onDrop={handleDrop}
                 header={
-                  <div className={`text-[11px] ${col.colorClass} font-bold mb-2 flex justify-between`}>
+                  <div className={`text-[13px] ${col.colorClass} font-bold mb-2 flex justify-between`}>
                     <span className="flex items-center gap-1">
                       <col.Icon className="w-3.5 h-3.5" />{t(col.labelKey)}
                     </span>
@@ -189,7 +214,7 @@ export default function TaskBoard({
                   ) : (
                     <button
                       onClick={() => setShowCreateForm(true)}
-                      className="w-full border border-dashed border-primary/50 rounded-lg py-2 text-[11px] text-primary hover:border-primary hover:bg-primary/5 transition mb-1"
+                      className="w-full border border-dashed border-primary/50 rounded-lg py-2 text-[13px] text-primary hover:border-primary hover:bg-primary/5 transition mb-1"
                     >
                       + {t("task.createNew")}
                     </button>
@@ -206,6 +231,7 @@ export default function TaskBoard({
                       onResume={onResumeTask}
                       onComplete={onCompleteTask}
                       onAssign={handleAssignClick}
+                      onClick={handleTaskClick}
                     />
                   </DraggableTaskCard>
                 ))}
@@ -215,7 +241,7 @@ export default function TaskBoard({
         </div>
 
         {/* Drag hint */}
-        <div className="px-4 py-2 text-center text-[10px] text-text-dim border-t border-border">
+        <div className="px-4 py-2 text-center text-[12px] text-text-dim border-t border-border">
           {t("task.dragHint")}
         </div>
       </div>
@@ -228,6 +254,38 @@ export default function TaskBoard({
           onAssign={handleAssignFromModal}
           onCancel={() => setAssignModal(null)}
         />
+      )}
+
+      {/* Task Report Modal */}
+      {reportModal && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50" onClick={() => setReportModal(null)}>
+          <div className="bg-surface-raised rounded-xl border border-border w-[90vw] max-w-[500px] max-h-[60vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+            <div className="px-4 py-3 border-b border-border flex justify-between items-center">
+              <span className="text-text font-bold text-[13px] flex items-center gap-1.5">
+                <FileText className="w-4 h-4" />{t("task.reportDetail")}
+              </span>
+              <button onClick={() => setReportModal(null)} className="text-text-muted hover:text-white"><X className="w-4 h-4" /></button>
+            </div>
+            <div className="px-4 py-3 border-b border-border">
+              <div className="text-text font-bold text-[13px] mb-1">{reportModal.task.title}</div>
+              {reportModal.task.summary && (
+                <div className="text-text-muted text-[12px]">{reportModal.task.summary}</div>
+              )}
+              {reportModal.task.npcName && (
+                <div className="text-npc text-[11px] mt-1">NPC: {reportModal.task.npcName}</div>
+              )}
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-3">
+              {reportModal.loading ? (
+                <div className="text-text-muted text-[12px] text-center py-4">{t("task.reportLoading")}</div>
+              ) : reportModal.message ? (
+                <div className="text-text text-[12px] whitespace-pre-wrap leading-relaxed">{reportModal.message}</div>
+              ) : (
+                <div className="text-text-dim text-[12px] text-center py-4">{t("task.noReport")}</div>
+              )}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -32,6 +32,7 @@ interface TaskCardProps {
   onResume?: (taskId: string) => void;
   onAssign?: (taskId: string) => void;
   onComplete?: (taskId: string) => void;
+  onClick?: (taskId: string) => void;
 }
 
 const STATUS_CONFIG: Record<string, { color: string; border: string; icon: React.ReactNode; labelKey: string }> = {
@@ -52,6 +53,7 @@ export default function TaskCard({
   onResume,
   onAssign,
   onComplete,
+  onClick,
 }: TaskCardProps) {
   const t = useT();
   const config = STATUS_CONFIG[task.status] || STATUS_CONFIG.pending;
@@ -83,18 +85,19 @@ export default function TaskCard({
     <div
       className={`bg-surface rounded-lg p-2.5 border-l-[3px] ${config.border} ${
         isFinished ? "opacity-60" : ""
-      }`}
+      } ${onClick ? "cursor-pointer hover:bg-surface-raised" : ""}`}
+      onClick={onClick ? () => onClick(task.id) : undefined}
     >
       <div className="flex justify-between items-center mb-1">
-        <span className={`text-[10px] font-bold ${config.color}`}>
+        <span className={`text-[12px] font-bold ${config.color}`}>
           {config.icon} {t(config.labelKey)}
         </span>
         <div className="flex items-center gap-1">
-          <span className="text-[9px] text-text-dim">{npcTaskId}</span>
+          <span className="text-[11px] text-text-dim">{npcTaskId}</span>
           {onDelete && (
             <button
               onClick={(e) => { e.stopPropagation(); onDelete(task.id); }}
-              className="text-text-dim hover:text-danger text-[10px] ml-1"
+              className="text-text-dim hover:text-danger text-[12px] ml-1"
               title={t("common.delete")}
             >
               x
@@ -104,17 +107,17 @@ export default function TaskCard({
       </div>
       <div className="text-text text-caption font-bold mb-1">{task.title}</div>
       {!compact && task.summary && (
-        <div className="text-text-muted text-[10px] mb-1.5 line-clamp-2">{task.summary}</div>
+        <div className="text-text-muted text-[12px] mb-1.5 line-clamp-2">{task.summary}</div>
       )}
       {nudgeLabel ? (
-        <div className="mb-1.5 text-[9px] text-text-dim">{nudgeLabel}</div>
+        <div className="mb-1.5 text-[11px] text-text-dim">{nudgeLabel}</div>
       ) : null}
       <div className="mb-2 flex flex-wrap gap-1.5">
         {(task.status === "pending" || task.status === "in_progress" || task.status === "stalled") && onComplete ? (
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onComplete(task.id); }}
-            className="rounded bg-success/20 px-2 py-1 text-[10px] text-success hover:bg-success/30"
+            className="rounded bg-success/20 px-2 py-1 text-[12px] text-success hover:bg-success/30"
           >
             {t("task.markComplete")}
           </button>
@@ -123,7 +126,7 @@ export default function TaskCard({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onRequestReport(task.id); }}
-            className="rounded bg-primary/20 px-2 py-1 text-[10px] text-primary hover:bg-primary/30"
+            className="rounded bg-primary/20 px-2 py-1 text-[12px] text-primary hover:bg-primary/30"
           >
             {t("task.requestReport")}
           </button>
@@ -132,7 +135,7 @@ export default function TaskCard({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onResume(task.id); }}
-            className="rounded bg-warning/20 px-2 py-1 text-[10px] text-warning hover:bg-warning/30"
+            className="rounded bg-warning/20 px-2 py-1 text-[12px] text-warning hover:bg-warning/30"
           >
             {t("task.resume")}
           </button>
@@ -141,20 +144,20 @@ export default function TaskCard({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onAssign(task.id); }}
-            className="rounded bg-primary/20 px-2 py-1 text-[10px] text-primary hover:bg-primary/30"
+            className="rounded bg-primary/20 px-2 py-1 text-[12px] text-primary hover:bg-primary/30"
           >
             {t("task.assign")}
           </button>
         ) : null}
       </div>
-      <div className="flex justify-between items-center text-[9px] text-text-dim">
+      <div className="flex justify-between items-center text-[11px] text-text-dim">
         {showNpcName && (
           npcName ? (
             <Badge variant="npc" size="sm">
               <Bot className="w-3 h-3" />{npcName}
             </Badge>
           ) : (
-            <span className="text-[9px] text-text-dim">{t("task.unassigned")}</span>
+            <span className="text-[11px] text-text-dim">{t("task.unassigned")}</span>
           )
         )}
         <span>{formatTimestamp(updatedAt)}</span>

--- a/src/components/TaskCreateForm.tsx
+++ b/src/components/TaskCreateForm.tsx
@@ -50,19 +50,19 @@ export default function TaskCreateForm({ onSubmit, onCancel }: TaskCreateFormPro
         onKeyDown={handleKeyDown}
         placeholder={t("task.summaryPlaceholder")}
         rows={2}
-        className="w-full bg-surface text-text text-[10px] rounded px-2 py-1.5 border border-border focus:outline-none focus:border-primary resize-none mb-1.5"
+        className="w-full bg-surface text-text text-[12px] rounded px-2 py-1.5 border border-border focus:outline-none focus:border-primary resize-none mb-1.5"
       />
       <div className="flex gap-1.5 justify-end">
         <button
           onClick={onCancel}
-          className="px-2 py-1 text-[10px] text-text-muted hover:text-text rounded"
+          className="px-2 py-1 text-[12px] text-text-muted hover:text-text rounded"
         >
           <X className="w-3 h-3 inline" />
         </button>
         <button
           onClick={handleSubmit}
           disabled={!title.trim()}
-          className="px-2.5 py-1 text-[10px] bg-primary text-white rounded hover:bg-primary/80 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1"
+          className="px-2.5 py-1 text-[12px] bg-primary text-white rounded hover:bg-primary/80 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1"
         >
           <Plus className="w-3 h-3" />
           {t("task.createNew")}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -2002,6 +2002,9 @@ const en: Record<string, string> = {
   "task.chatPlaceholder": "Send additional instructions about this task.",
   "task.register": "Register",
   "task.registered": "Registered",
+  "task.reportDetail": "Task Detail",
+  "task.noReport": "No report available yet.",
+  "task.reportLoading": "Loading report...",
 };
 
 export default en;

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -2001,6 +2001,9 @@ const ja: Record<string, string> = {
   "task.chatPlaceholder": "タスクについて追加の指示を送信してください。",
   "task.register": "登録",
   "task.registered": "登録済み",
+  "task.reportDetail": "タスク詳細",
+  "task.noReport": "まだ報告がありません。",
+  "task.reportLoading": "レポートを取得中...",
 };
 
 export default ja;

--- a/src/lib/i18n/locales/ko.ts
+++ b/src/lib/i18n/locales/ko.ts
@@ -2003,6 +2003,9 @@ const ko: Record<string, string> = {
   "task.chatPlaceholder": "태스크에 대해 추가 지시를 보내보세요.",
   "task.register": "등록",
   "task.registered": "등록됨",
+  "task.reportDetail": "태스크 상세",
+  "task.noReport": "아직 보고된 내용이 없습니다.",
+  "task.reportLoading": "보고서 조회 중...",
 };
 
 export default ko;

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -2001,6 +2001,9 @@ const zh: Record<string, string> = {
   "task.chatPlaceholder": "发送关于此任务的额外指示。",
   "task.register": "登记",
   "task.registered": "已登记",
+  "task.reportDetail": "任务详情",
+  "task.noReport": "暂无报告内容。",
+  "task.reportLoading": "正在加载报告...",
 };
 
 export default zh;

--- a/src/lib/task-manager.js
+++ b/src/lib/task-manager.js
@@ -371,6 +371,45 @@ class TaskManager {
     return { ...task, _fromStatus: fromStatus };
   }
 
+  /**
+   * Check if the NPC currently has any in_progress task in the given channel.
+   */
+  async hasInProgressTask(npcId, channelId) {
+    const { db, schema } = this;
+    const rows = await db
+      .select({ id: schema.tasks.id })
+      .from(schema.tasks)
+      .where(
+        and(
+          eq(schema.tasks.npcId, npcId),
+          eq(schema.tasks.channelId, channelId),
+          eq(schema.tasks.status, "in_progress"),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  /**
+   * Get the oldest pending task for the given NPC in the channel (FIFO).
+   */
+  async getNextPendingTask(npcId, channelId) {
+    const { db, schema } = this;
+    const rows = await db
+      .select()
+      .from(schema.tasks)
+      .where(
+        and(
+          eq(schema.tasks.npcId, npcId),
+          eq(schema.tasks.channelId, channelId),
+          eq(schema.tasks.status, "pending"),
+        ),
+      )
+      .orderBy(schema.tasks.createdAt)
+      .limit(1);
+    return rows[0] ? normalizeTask(rows[0]) : null;
+  }
+
   async getTaskByNpcTaskId(npcId, npcTaskId) {
     const { db, schema } = this;
 

--- a/src/lib/task-reporting.ts
+++ b/src/lib/task-reporting.ts
@@ -323,6 +323,23 @@ export async function getPendingReportsForUserAndChannel(
   return (rows as ReportRow[]).map((row: ReportRow) => normalizeReportRow(row)).filter((row): row is QueuedReportRow => row !== null);
 }
 
+export async function getReportsByTaskId(
+  db: unknown,
+  schema: unknown,
+  taskId: string,
+): Promise<QueuedReportRow[]> {
+  const reportDb = asReportDb(db);
+  const reportSchema = asReportSchema(schema);
+  const reports = reportSchema.npcReports;
+  const rows = await reportDb
+    .select()
+    .from(reports)
+    .where(eq((reports as unknown as { taskId: SQLWrapper }).taskId, taskId))
+    .orderBy(asc(reports.createdAt));
+
+  return (rows as ReportRow[]).map((row: ReportRow) => normalizeReportRow(row)).filter((row): row is QueuedReportRow => row !== null);
+}
+
 export function toReportReadyPayload(
   report: Pick<QueuedReportRow, "id" | "npcId" | "message" | "kind">,
   npcName?: string,

--- a/src/server/socket-handlers.ts
+++ b/src/server/socket-handlers.ts
@@ -38,6 +38,7 @@ import {
   buildQueuedReportRow,
   buildManualTaskReportPrompt,
   enqueueCompletionReport,
+  getReportsByTaskId,
   enqueueQueuedReport,
   getProgressNudgeCutoff,
   getPendingReportsForUserAndChannel,
@@ -60,7 +61,7 @@ const { parseNpcResponse, isValidTaskAction } = require("../lib/task-parser.js")
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { sanitizeNpcResponseText } = require("../lib/task-block-utils.js") as typeof import("../lib/task-block-utils.js");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { TaskManager } = require("../lib/task-manager.js") as { TaskManager: new (db: typeof import("../db").db, schema: { tasks: typeof tasks; npcs: typeof npcs }) => { handleTaskAction: (...args: unknown[]) => Promise<unknown>; getTasksByNpc: (npcId: string) => Promise<unknown[]>; getTasksByChannel: (channelId: string) => Promise<unknown[]>; deleteTask: (taskId: string, channelId: string) => Promise<unknown>; getStaleInProgressTasks: (channelId: string, olderThanIso: string) => Promise<unknown[]>; markTaskNudged: (taskId: string, channelId: string) => Promise<unknown>; markTaskStalled: (taskId: string, channelId: string, reason: string) => Promise<unknown>; resumeTask: (taskId: string, channelId: string) => Promise<unknown>; completeTask: (taskId: string, channelId: string) => Promise<unknown>; createBacklogTask: (channelId: string, assignerId: string, title: string, summary: string | null) => Promise<unknown>; moveTask: (taskId: string, channelId: string, toStatus: string, npcId: string | null) => Promise<unknown>; getTaskById: (taskId: string, channelId: string) => Promise<unknown>; getTaskByNpcTaskId: (npcId: string, npcTaskId: string) => Promise<unknown>; }; };
+const { TaskManager } = require("../lib/task-manager.js") as { TaskManager: new (db: typeof import("../db").db, schema: { tasks: typeof tasks; npcs: typeof npcs }) => { handleTaskAction: (...args: unknown[]) => Promise<unknown>; getTasksByNpc: (npcId: string) => Promise<unknown[]>; getTasksByChannel: (channelId: string) => Promise<unknown[]>; deleteTask: (taskId: string, channelId: string) => Promise<unknown>; getStaleInProgressTasks: (channelId: string, olderThanIso: string) => Promise<unknown[]>; markTaskNudged: (taskId: string, channelId: string) => Promise<unknown>; markTaskStalled: (taskId: string, channelId: string, reason: string) => Promise<unknown>; resumeTask: (taskId: string, channelId: string) => Promise<unknown>; completeTask: (taskId: string, channelId: string) => Promise<unknown>; createBacklogTask: (channelId: string, assignerId: string, title: string, summary: string | null) => Promise<unknown>; moveTask: (taskId: string, channelId: string, toStatus: string, npcId: string | null) => Promise<unknown>; getTaskById: (taskId: string, channelId: string) => Promise<unknown>; getTaskByNpcTaskId: (npcId: string, npcTaskId: string) => Promise<unknown>; hasInProgressTask: (npcId: string, channelId: string) => Promise<boolean>; getNextPendingTask: (npcId: string, channelId: string) => Promise<ManagedTask | null>; }; };
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { withTaskReminder, normalizeTaskPromptLocale, buildTaskSessionPrompt } = require("../lib/task-prompt.js") as typeof import("../lib/task-prompt.js");
 
@@ -295,6 +296,16 @@ async function processNpcTaskActions(
           title: task.title,
           summary: (task as Record<string, unknown>).summary as string || "",
         });
+
+        // Auto-promote next pending task for the same NPC (FIFO)
+        const nextTask = await taskManager.getNextPendingTask(input.npcId, input.channelId);
+        if (nextTask) {
+          const promoted = await taskManager.moveTask(nextTask.id, input.channelId, "in_progress", input.npcId) as (ManagedTask & { _fromStatus?: string }) | null;
+          if (promoted) {
+            const { _fromStatus, ...promotedTask } = promoted;
+            io.to(input.channelId).emit("task:updated", { task: promotedTask, action: "move_pending_in_progress" });
+          }
+        }
       }
 
       if (shouldDeliverCompletionReport(taskAction as { action?: string })) {
@@ -1291,15 +1302,23 @@ export function setupSocketHandlers(io: Server) {
         const allowedStatuses = ["backlog", "pending", "in_progress", "stalled", "complete", "cancelled"];
         if (!allowedStatuses.includes(toStatus)) return;
 
-        const movedTask = await taskManager.moveTask(taskId, player.mapId, toStatus, npcId || null) as (ManagedTask & { _fromStatus?: string }) | null;
+        // If requesting in_progress but NPC already has an in_progress task, demote to pending
+        let finalToStatus = toStatus;
+        const effectiveNpcId = npcId || null;
+        if (toStatus === "in_progress" && effectiveNpcId) {
+          const busy = await taskManager.hasInProgressTask(effectiveNpcId, player.mapId);
+          if (busy) finalToStatus = "pending";
+        }
+
+        const movedTask = await taskManager.moveTask(taskId, player.mapId, finalToStatus, effectiveNpcId) as (ManagedTask & { _fromStatus?: string }) | null;
         if (!movedTask) return;
 
         const fromStatus = movedTask._fromStatus;
         const { _fromStatus, ...task } = movedTask;
-        io.to(player.mapId).emit("task:updated", { task, action: `move_${fromStatus}_${toStatus}` });
+        io.to(player.mapId).emit("task:updated", { task, action: `move_${fromStatus}_${finalToStatus}` });
 
         if (
-          toStatus === "in_progress" &&
+          finalToStatus === "in_progress" &&
           (fromStatus === "backlog" || fromStatus === "pending") &&
           task.npcId
         ) {
@@ -1455,9 +1474,79 @@ export function setupSocketHandlers(io: Server) {
         const completedTask = await taskManager.completeTask(taskId, player.mapId) as ManagedTask | null;
         if (completedTask) {
           io.to(player.mapId).emit("task:updated", { task: completedTask, action: "complete_manual" });
+
+          // Auto-promote next pending task for the same NPC (FIFO)
+          if (completedTask.npcId) {
+            const nextTask = await taskManager.getNextPendingTask(completedTask.npcId, player.mapId);
+            if (nextTask) {
+              const promoted = await taskManager.moveTask(nextTask.id, player.mapId, "in_progress", completedTask.npcId) as (ManagedTask & { _fromStatus?: string }) | null;
+              if (promoted) {
+                const { _fromStatus, ...promotedTask } = promoted;
+                io.to(player.mapId).emit("task:updated", { task: promotedTask, action: "move_pending_in_progress" });
+
+                // Trigger NPC to start working on the promoted task
+                const npcConfig = await getNpcConfig(completedTask.npcId);
+                if (npcConfig) {
+                  const taskSessionPrompt = buildTaskSessionPrompt({
+                    ...promotedTask,
+                    summary: promotedTask.summary || "",
+                    createdAt: (promotedTask as { createdAt?: string }).createdAt || "",
+                  }, getSocketLocale(socket));
+                  const autoStartMessage = withTaskReminder(`${promotedTask.title} 업무를 시작합니다.`, getSocketLocale(socket));
+                  const messageToSend = `${taskSessionPrompt}\n\n${autoStartMessage}`;
+                  const sessionKey = `${npcConfig.sessionKeyPrefix || completedTask.npcId}-task-${promotedTask.npcTaskId}`;
+
+                  const response = await streamNpcResponse(
+                    socket,
+                    completedTask.npcId,
+                    npcConfig,
+                    player.userId,
+                    messageToSend,
+                    undefined,
+                    sessionKey,
+                    "npc:task-response",
+                  );
+
+                  if (response) {
+                    const parsed = parseNpcResponse(response);
+                    await processNpcTaskActions(io, parsed, {
+                      channelId: player.mapId,
+                      npcId: completedTask.npcId,
+                      npcName: npcConfig._name,
+                      assignerCharacterId: player.characterId,
+                      targetUserId: player.userId,
+                    });
+                    socket.emit("npc:response-complete", {
+                      npcId: completedTask.npcId,
+                      npcName: npcConfig._name || completedTask.npcId,
+                    });
+                  }
+                }
+              }
+            }
+          }
         }
       } catch (err) {
         console.error("[TaskManager] Error completing task:", err);
+      }
+    });
+
+    socket.on("task:get-report", async ({ taskId }: { taskId: string }) => {
+      try {
+        const player = players.get(socket.id);
+        if (!player || !taskId) return;
+
+        const reports = await getReportsByTaskId(db, { npcReports }, taskId);
+        const lastReport = reports.length > 0 ? reports[reports.length - 1] : null;
+        socket.emit("task:report", {
+          taskId,
+          message: lastReport?.message || null,
+          kind: lastReport?.kind || null,
+          createdAt: lastReport?.createdAt || null,
+        });
+      } catch (err) {
+        console.error("[TaskManager] Error getting task report:", err);
+        socket.emit("task:report", { taskId, message: null, kind: null, createdAt: null });
       }
     });
 


### PR DESCRIPTION
## Summary
- **폰트 크기 증가**: 태스크 보드 전체 텍스트 크기 +2px (9→11, 10→12, 11→13px)
- **자동 승격**: 백로그 할당 시 NPC가 놀고 있으면 바로 `in_progress`, 바쁘면 `pending` 대기 → 작업 완료 시 FIFO 자동 승격
- **보고서 모달**: 태스크 카드 클릭 시 완료 보고서를 모달로 즉시 조회

## Changes
| 파일 | 변경 |
|------|------|
| `TaskBoard.tsx` | 보고서 모달 UI, 자동 할당 목표 상태 변경, 폰트 크기 |
| `TaskCard.tsx` | onClick prop, 폰트 크기 |
| `TaskCreateForm.tsx` | 폰트 크기 |
| `task-manager.js` | `hasInProgressTask()`, `getNextPendingTask()` |
| `task-reporting.ts` | `getReportsByTaskId()` |
| `socket-handlers.ts` | `task:get-report` 이벤트, 자동 승격 로직, NPC 바쁨 감지 |
| `locales/*.ts` | `task.reportDetail/noReport/reportLoading` (ko/en/ja/zh) |

## Test plan
- [ ] 백로그에서 NPC 할당 → NPC가 놀고 있으면 바로 진행중 확인
- [ ] 백로그에서 NPC 할당 → NPC가 바쁘면 대기 상태 확인
- [ ] 태스크 완료 시 같은 NPC의 대기 태스크가 자동으로 진행중 전환 확인
- [ ] 태스크 카드 클릭 → 보고서 모달 표시 확인
- [ ] 보고서가 없는 태스크 클릭 → "아직 보고된 내용이 없습니다" 메시지 확인
- [ ] 폰트 크기 증가 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises task board text by 2px, adds FIFO auto-promotion for NPC tasks, and lets you open a task’s latest report in a modal by clicking the card. Assigning to a busy NPC now goes to pending automatically.

- **New Features**
  - Auto-promote and auto-start: when a task completes, the next pending task for the same NPC moves to in_progress (FIFO) and the NPC is prompted to begin.
  - Assign safety: assigning to an NPC with an active task lands in pending; if idle, it starts in_progress.
  - Report modal: click a task to fetch and view its latest report via task:get-report/task:report; added i18n keys for messages.
  - UI: increased font sizes across TaskBoard, TaskCard, and TaskCreateForm (+2px).

<sup>Written for commit 0a91450423493a058bef7cf19b76bfe72d9e474e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

